### PR TITLE
feat: disable auto consent  and add `nuxt telemetry consent`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,11 +45,18 @@ function _run () {
       consola.info('You can enable telemetry with `npx nuxt telemetry enable ' + (global ? '-g' : _dir) + '`')
       return
     case 'status':
-      showStatus()
-      return
+      return showStatus()
     case 'consent':
     default:
-      ensureUserconsent({} as any)
+      return _prompt()
+  }
+
+  async function _prompt () {
+    const accepted = await ensureUserconsent({} as any)
+    if (accepted) {
+      setRC('telemetry.enabled', true)
+      setRC('telemetry.consent', consentVersion)
+    }
   }
 
   function _checkDisabled (): string | false {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,8 +47,9 @@ function _run () {
     case 'status':
       return showStatus()
     case 'consent':
-    default:
       return _prompt()
+    default:
+      showUsage()
   }
 
   async function _prompt () {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,8 +10,9 @@ import jiti from 'jiti'
 import env from 'std-env'
 import dotenv from 'dotenv'
 import { consentVersion } from './meta'
+import { ensureUserconsent } from './consent'
 
-export const usage = 'nuxt telemetry `status`|`enable`|`disable` [`-g`,`--global`] [`dir`]'
+export const usage = 'nuxt telemetry `status`|`enable`|`disable`|`consent` [`-g`,`--global`] [`dir`]'
 const RC_FILENAME = '.nuxtrc'
 
 function _run () {
@@ -46,8 +47,9 @@ function _run () {
     case 'status':
       showStatus()
       return
+    case 'consent':
     default:
-      showUsage()
+      ensureUserconsent({} as any)
   }
 
   function _checkDisabled (): string | false {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,7 @@ function _run () {
       setRC('telemetry.enabled', true)
       setRC('telemetry.consent', consentVersion)
     }
+    showStatus()
   }
 
   function _checkDisabled (): string | false {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,8 +53,8 @@ function _run () {
   }
 
   async function _prompt () {
-    const accepted = await ensureUserconsent({} as any)
-    if (accepted) {
+    const accepted = await ensureUserconsent({} as any) // <-- always sets global
+    if (accepted && !global) {
       setRC('telemetry.enabled', true)
       setRC('telemetry.consent', consentVersion)
     }

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -8,12 +8,12 @@ import { TelemetryOptions } from './types'
 import { consentVersion } from './meta'
 
 export async function ensureUserconsent (options: TelemetryOptions): Promise<boolean> {
-  if (stdEnv.minimal || process.env.CODESANDBOX_SSE || isDocker()) {
-    return false
-  }
-
   if (options.consent >= consentVersion) {
     return true
+  }
+
+  if (stdEnv.minimal || process.env.CODESANDBOX_SSE || isDocker()) {
+    return false
   }
 
   process.stdout.write('\n')

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -8,7 +8,11 @@ import { TelemetryOptions } from './types'
 import { consentVersion } from './meta'
 
 export async function ensureUserconsent (options: TelemetryOptions): Promise<boolean> {
-  if (options.consent >= consentVersion || stdEnv.minimal || process.env.CODESANDBOX_SSE || isDocker()) {
+  if (stdEnv.minimal || process.env.CODESANDBOX_SSE || isDocker()) {
+    return false
+  }
+
+  if (options.consent >= consentVersion) {
     return true
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -32,7 +32,8 @@ export async function createContext (nuxt: Nuxt, options: TelemetryOptions): Pro
     nodeVersion,
     os: os.type().toLocaleLowerCase(),
     environment: getEnv(),
-    packageManager
+    packageManager,
+    concent: options.consent
   }
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,7 +25,8 @@ export interface Context {
   os: string
   git?: { url: string }
   environment: string | null
-  packageManager: string
+  packageManager: string,
+  concent: number
 }
 
 export interface Event {


### PR DESCRIPTION
**Background:** For sending telemetry events, we once consent users about sending events or not but since it wasn't possible to make a prompt and await on stdin in production and CI/CD environments, it was enabled by default on headless envs. (alternative was forcing on each project creation but at early days it was reported to be annoying even with a notice how to enable in CI)

With this change, we **never** send any events unless it is explicitly enabled per-machine or per-project. 

Also a new cli command `nuxt telemetry consent [-g] [dir]` introduced so with a post creation hook in create-nuxt-app, we still have chance to opt in users but before first run.

Also I added `consent` field to events context so if later-on we change events policy, have a way to distinguish events. (clarify: currently if a policy change happens, we shall bump version to force prompt users again before sending events.)

**Rolling-out strategy:**

- All events with production env or `ci: true` tag will be wiped out from database to maximize privacy 
- Older versions of `@nuxt/telemetry` npm package will be deprecated with a message to notify about implicit behavior and they should upgrade version
- New version is released as a semver-minor so essentially any new nuxt project will receive update without need to release another version of nuxt

closes #34