### PR TITLE
fix: provide fallback to `require.main.filename`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -54,7 +54,7 @@ function getEnv (): Context['environment'] {
 }
 
 function getCLI () {
-  const entry = require.main.filename
+  const entry = require.main?.filename || process.argv.join(' ')
 
   const knownCLIs = {
     'nuxt-ts.js': 'nuxt-ts',


### PR DESCRIPTION
* allows usage in a `type: module` context

closes #49