### PR TITLE
chore(deps): update std-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node-fetch": "^2.6.1",
     "parse-git-config": "^3.0.0",
     "rc9": "^1.2.0",
-    "std-env": "^2.3.0"
+    "std-env": "^3.0.1"
   },
   "devDependencies": {
     "@nuxt/types": "latest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import * as rc from 'rc9'
 import c from 'chalk'
 import consola from 'consola'
 import jiti from 'jiti'
-import env from 'std-env'
+import { isTest } from 'std-env'
 import dotenv from 'dotenv'
 import { consentVersion } from './meta'
 import { ensureUserconsent } from './consent'
@@ -63,7 +63,7 @@ function _run () {
 
   function _checkDisabled (): string | false {
     // test
-    if (env.test) {
+    if (isTest) {
       return 'Because running in test environment'
     }
 

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -1,7 +1,7 @@
 import c from 'chalk'
 import inquirer from 'inquirer'
 import consola from 'consola'
-import stdEnv from 'std-env'
+import { isMinimal } from 'std-env'
 import isDocker from 'is-docker'
 import { updateUserNuxtRc } from './utils/nuxtrc'
 import { TelemetryOptions } from './types'
@@ -12,7 +12,7 @@ export async function ensureUserconsent (options: TelemetryOptions): Promise<boo
     return true
   }
 
-  if (stdEnv.minimal || process.env.CODESANDBOX_SSE || process.env.NEXT_TELEMETRY_DISABLED /* stackblitz */ || isDocker()) {
+  if (isMinimal || process.env.CODESANDBOX_SSE || process.env.NEXT_TELEMETRY_DISABLED /* stackblitz */ || isDocker()) {
     return false
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9534,6 +9534,11 @@ std-env@^2.2.1, std-env@^2.3.0:
   dependencies:
     ci-info "^3.0.0"
 
+std-env@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.0.1.tgz#bc4cbc0e438610197e34c2d79c3df30b491f5182"
+  integrity sha512-mC1Ps9l77/97qeOZc+HrOL7TIaOboHqMZ24dGVQrlxFcpPpfCHpH+qfUT7Dz+6mlG8+JPA1KfBQo19iC/+Ngcw==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
Tried to migrate Nuxt 2 project to Bridge and got an error because `std-env@2` gets hoisted and fails with:

```
ERROR  [worker reload] [worker init] Named export 'provider' not found. The requested module 'file:///usr/local/workspace/web/project/node_modules/std-env/index.js' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'file:///usr/local/workspace/web/project/node_modules/std-env/index.js';
const { provider, isWindows } = pkg;


  import { provider, isWindows } from 'node_modules/std-env/index.js';
  ^^^^^^^^
  SyntaxError: Named export 'provider' not found. The requested module 'node_modules/std-env/index.js' is a CommonJS module, which may not support all module.exports as named exports.
  CommonJS modules can always be imported via the default export, for example using:

  import pkg from 'node_modules/std-env/index.js';
  const { provider, isWindows } = pkg;

  at ModuleJob._instantiate (internal/modules/esm/module_job.js:124:21)
  at async ModuleJob.run (internal/modules/esm/module_job.js:179:5)
  at async Loader.import (internal/modules/esm/loader.js:178:24)
  at async Object.loadESM (internal/process/esm_loader.js:68:5)
```