### PR TITLE
feat: expose hooks for extensibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nuxt/telemetry",
+  "packageManager": "pnpm@8.7.6",
   "version": "2.4.1",
   "repository": "nuxt/telemetry",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,7 +49,7 @@ export default defineNuxtModule<TelemetryOptions>({
 
     const t = new Telemetry(nuxt, toptions)
 
-    nuxt.hook('modules:done', () => {
+    nuxt.hook('modules:done', async () => {
       t.createEvent('project')
       // Only send the session in development
       if (nuxt.options.dev) {
@@ -58,6 +58,7 @@ export default defineNuxtModule<TelemetryOptions>({
       }
       t.createEvent('command')
       t.createEvent('module')
+      await nuxt.callHook('telemetry:setup', t)
       t.sendEvents(toptions.debug)
     })
   }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,6 +1,6 @@
 import type { Nuxt } from '@nuxt/schema'
 import { postEvent } from './utils/post-event'
-import * as events from './events/index'
+import * as eventFactories from './events/index'
 import { createContext } from './context'
 import { EventFactory, TelemetryOptions, Context, EventFactoryResult } from './types'
 import { logger } from './utils/log'
@@ -11,6 +11,7 @@ export class Telemetry {
   storage: any // TODO
   _contextPromise?: Promise<Context>
   events: Promise<EventFactoryResult<any>>[] = []
+  eventFactories: Record<string, EventFactory<any>> = { ...eventFactories }
 
   constructor (nuxt: Nuxt, options: TelemetryOptions) {
     this.nuxt = nuxt
@@ -25,8 +26,7 @@ export class Telemetry {
   }
 
   createEvent (name: string, payload?: object): void | Promise<any> {
-    // @ts-ignore
-    const eventFactory: EventFactory<any> = (events as any)[name]
+    const eventFactory = this.eventFactories[name]
     if (typeof eventFactory !== 'function') {
       logger.warn('Unknown event:', name)
       return

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -48,7 +48,7 @@ export class Telemetry {
 
   async getPublicContext () {
     const context = await this.getContext()
-    const eventContext = {}
+    const eventContext: Record<string, any> = {}
     for (const key of [
       'nuxtVersion',
       'nuxtMajorVersion',
@@ -59,7 +59,7 @@ export class Telemetry {
       'environment',
       'projectHash',
       'projectSession'
-    ]) {
+    ] as const) {
       eventContext[key] = context[key]
     }
     return eventContext

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
+import { Telemetry } from './telemetry'
 
 export interface TelemetryOptions {
   debug: boolean
@@ -48,4 +49,10 @@ export interface GitData {
   source: string
   owner: string
   name: string
+}
+
+declare module '@nuxt/schema' {
+  interface NuxtHooks {
+    'telemetry:setup': (telemetry: Telemetry) => void
+  }
 }


### PR DESCRIPTION
For Nuxt DevTools to logs it's own events. I am not sure if there is a way to prevent arbitrary modules from hooking into it tho. 