### PR TITLE
fix: do not chain consola colors

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -19,7 +19,7 @@ export async function ensureUserconsent (options: TelemetryOptions): Promise<boo
   process.stdout.write('\n')
   consola.info(`${c.green('Nuxt')} collects completely anonymous data about usage.
   This will help us improve Nuxt developer experience over time.
-  Read more on ${c.cyan.underline('https://github.com/nuxt/telemetry')}\n`)
+  Read more on ${c.underline(c.cyan('https://github.com/nuxt/telemetry'))}\n`)
 
   const accepted = await consola.prompt('Are you interested in participating?', {
     type: 'confirm'


### PR DESCRIPTION
It appears that chalk used to have this api `c.cyan.underline` but consola doesn't seem to have the same i.e. you can't chain methods.
This should fix that issue.
The original issue was posted here https://github.com/nuxt/nuxt/issues/23489. The error the user faced is noted down there.

resolves https://github.com/nuxt/nuxt/issues/23489