### PR TITLE
fix(cli): use `@nuxt/kit` to load nuxt config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "dotenv": "^16.4.7",
     "git-url-parse": "^16.0.0",
     "is-docker": "^3.0.0",
-    "jiti": "^2.4.2",
     "ofetch": "^1.4.1",
     "package-manager-detector": "^0.2.8",
     "parse-git-config": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       is-docker:
         specifier: ^3.0.0
         version: 3.0.0
-      jiti:
-        specifier: ^2.4.2
-        version: 2.4.2
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -164,7 +164,7 @@ async function ensureNuxtProject(args: { global: boolean, dir: string }) {
   }
   const dir = resolve(args.dir)
   const nuxtConfig = await loadNuxtConfig({ cwd: dir })
-  if (!nuxtConfig) {
+  if (!nuxtConfig || !nuxtConfig._layers[0]?.configFile) {
     consola.error('You are not in a Nuxt project.')
     consola.info('You can try specifying a directory or by using the `--global` flag to configure telemetry for your machine.')
     process.exit()


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

using `jiti` to import `nuxt.config` would have issues with undefined `defineNuxtConfig`.

Using `loadNuxtConfig` also allows us to respect (and identify!) whether layers have disabled telemetry