### PR TITLE
fix: remove dependency to parse-git-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "is-docker": "^3.0.0",
     "ofetch": "^1.4.1",
     "package-manager-detector": "^1.1.0",
-    "parse-git-config": "^3.0.0",
     "pathe": "^2.0.3",
     "rc9": "^2.1.2",
     "std-env": "^3.8.1"
@@ -64,7 +63,6 @@
     "@nuxt/schema": "^3.15.4",
     "@nuxt/test-utils": "^3.17.2",
     "@types/git-url-parse": "^9.0.3",
-    "@types/parse-git-config": "^3.0.4",
     "@vitest/coverage-v8": "^3.0.9",
     "changelogen": "^0.6.1",
     "eslint": "^9.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       package-manager-detector:
         specifier: ^1.1.0
         version: 1.1.0
-      parse-git-config:
-        specifier: ^3.0.0
-        version: 3.0.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -66,9 +63,6 @@ importers:
       '@types/git-url-parse':
         specifier: ^9.0.3
         version: 9.0.3
-      '@types/parse-git-config':
-        specifier: ^3.0.4
-        version: 3.0.4
       '@vitest/coverage-v8':
         specifier: ^3.0.9
         version: 3.0.9(vitest@3.0.9(@types/node@18.13.0)(jiti@2.4.2)(terser@5.18.2)(yaml@2.7.0))
@@ -92,7 +86,7 @@ importers:
         version: 5.46.0(@types/node@18.13.0)(typescript@5.8.2)
       nuxt:
         specifier: ^3.15.4
-        version: 3.15.4(@parcel/watcher@2.4.1)(@types/node@18.13.0)(db0@0.2.1)(encoding@0.1.13)(eslint@9.22.0(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.34.8)(terser@5.18.2)(typescript@5.8.2)(vite@6.2.1(@types/node@18.13.0)(jiti@2.4.2)(terser@5.18.2)(yaml@2.7.0))(vue-tsc@2.2.8(typescript@5.8.2))(yaml@2.7.0)
+        version: 3.15.4(@parcel/watcher@2.4.1)(@types/node@18.13.0)(db0@0.2.1)(encoding@0.1.13)(eslint@9.22.0(jiti@2.4.2))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.34.8)(terser@5.18.2)(typescript@5.8.2)(vite@6.2.1(@types/node@18.13.0)(jiti@2.4.2)(terser@5.18.2)(yaml@2.7.0))(vue-tsc@2.2.8(typescript@5.8.2))(yaml@2.7.0)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -1284,9 +1278,6 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-
-  '@types/parse-git-config@3.0.4':
-    resolution: {integrity: sha512-jz5eGdk9lBgAd4rMbXTP7MRG7AsGQ8DrXsRumDcXDLClHcpKluislylPVMP/qp90J/LlIrrPZRZIQUflHfrDnQ==}
 
   '@types/parse-path@7.0.3':
     resolution: {integrity: sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==}
@@ -2489,10 +2480,6 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
-  git-config-path@2.0.0:
-    resolution: {integrity: sha512-qc8h1KIQbJpp+241id3GuAtkdyJ+IK+LIVtkiFTRKRrmddDzs3SI9CvP1QYmWBFvm1I/PWRwj//of8bgAc0ltA==}
-    engines: {node: '>=4'}
-
   git-up@8.0.0:
     resolution: {integrity: sha512-uBI8Zdt1OZlrYfGcSVroLJKgyNNXlgusYFzHk614lTasz35yg2PVpL1RMy0LOO2dcvF9msYW3pRfUSmafZNrjg==}
 
@@ -2665,9 +2652,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
@@ -3300,10 +3284,6 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  parse-git-config@3.0.0:
-    resolution: {integrity: sha512-wXoQGL1D+2COYWCD35/xbiKma1Z15xvZL8cI25wvxzled58V51SJM04Urt/uznS900iQor7QO04SgdfT/XlbuA==}
-    engines: {node: '>=8'}
 
   parse-imports@2.1.1:
     resolution: {integrity: sha512-TDT4HqzUiTMO1wJRwg/t/hYk8Wdp3iF/ToMIlAoVQfL1Xs/sTxq1dKWSMjMbQmIarfWKymOyly40+zmPHXMqCA==}
@@ -6041,8 +6021,6 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@types/parse-git-config@3.0.4': {}
-
   '@types/parse-path@7.0.3': {}
 
   '@types/resolve@1.20.2': {}
@@ -7568,8 +7546,6 @@ snapshots:
       nypm: 0.6.0
       pathe: 2.0.3
 
-  git-config-path@2.0.0: {}
-
   git-up@8.0.0:
     dependencies:
       is-ssh: 1.4.0
@@ -7772,8 +7748,6 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   ini@4.1.1: {}
 
@@ -8473,7 +8447,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@3.15.4(@parcel/watcher@2.4.1)(@types/node@18.13.0)(db0@0.2.1)(encoding@0.1.13)(eslint@9.22.0(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.34.8)(terser@5.18.2)(typescript@5.8.2)(vite@6.2.1(@types/node@18.13.0)(jiti@2.4.2)(terser@5.18.2)(yaml@2.7.0))(vue-tsc@2.2.8(typescript@5.8.2))(yaml@2.7.0):
+  nuxt@3.15.4(@parcel/watcher@2.4.1)(@types/node@18.13.0)(db0@0.2.1)(encoding@0.1.13)(eslint@9.22.0(jiti@2.4.2))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.34.8)(terser@5.18.2)(typescript@5.8.2)(vite@6.2.1(@types/node@18.13.0)(jiti@2.4.2)(terser@5.18.2)(yaml@2.7.0))(vue-tsc@2.2.8(typescript@5.8.2))(yaml@2.7.0):
     dependencies:
       '@nuxt/cli': 3.21.1(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
@@ -8714,11 +8688,6 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parse-git-config@3.0.0:
-    dependencies:
-      git-config-path: 2.0.0
-      ini: 1.3.8
 
   parse-imports@2.1.1:
     dependencies:

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import os from 'node:os'
+import { execSync } from 'node:child_process'
 import gitUrlParse from 'git-url-parse'
-import parseGitConfig from 'parse-git-config'
 import { getNuxtVersion, isNuxt3 } from '@nuxt/kit'
 import isDocker from 'is-docker'
 import { provider } from 'std-env'
@@ -90,18 +90,17 @@ function getProjectHash(rootDir: string, git?: GitData, seed?: string) {
   return hash(id)
 }
 
-async function getGitRemote(rootDir: string): Promise<string | null> {
+async function getGitRemote(cwd: string): Promise<string | null> {
+  let gitRemoteUrl = null
+
   try {
-    const parsed = await parseGitConfig({ cwd: rootDir })
-    if (parsed) {
-      const gitRemote = parsed['remote "origin"'].url
-      return gitRemote
-    }
-    return null
+    gitRemoteUrl = execSync('git config --get remote.origin.url  ', { encoding: 'utf8', cwd }).trim() || null
   }
   catch {
-    return null
+    /* ignore */
   }
+
+  return gitRemoteUrl
 }
 
 async function getGit(rootDir: string): Promise<GitData | undefined> {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #248 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR attempts to remove the dependency to the parse-git-config, which has not been released for
7 years and might not be released. Instead it uses a raw git command to fetch the remote.origin.url
