### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   ],
   "scripts": {
     "build": "nuxt-module-build build",
-    "dev": "NUXT_TELEMETRY_DEBUG=1 nuxi dev playground",
-    "dev:build": "NUXT_TELEMETRY_DEBUG=1 nuxi build playground",
-    "dev:generate": "NUXT_TELEMETRY_DEBUG=1 nuxi generate playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
+    "dev": "NUXT_TELEMETRY_DEBUG=1 nuxt dev playground",
+    "dev:build": "NUXT_TELEMETRY_DEBUG=1 nuxt build playground",
+    "dev:generate": "NUXT_TELEMETRY_DEBUG=1 nuxt generate playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare playground",
     "lint": "eslint .",
     "nuxt-telemetry": "node ./bin/nuxt-telemetry.mjs",
     "prepack": "nuxt-module-build build",
@@ -41,7 +41,7 @@
     "test": "vitest run",
     "test:engines": "installed-check -d --no-workspaces",
     "test:knip": "knip",
-    "test:types": "nuxt-module-build prepare && nuxi prepare playground && vue-tsc --noEmit"
+    "test:types": "nuxt-module-build prepare && nuxt prepare playground && vue-tsc --noEmit"
   },
   "dependencies": {
     "@nuxt/kit": "^3.17.4",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.